### PR TITLE
Label ISO with 'ZTC SNO'

### DIFF
--- a/internal/imageserver/imageserver.go
+++ b/internal/imageserver/imageserver.go
@@ -75,7 +75,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	if err := create(outPath, isoWorkDir, "relocation-config"); err != nil {
+	if err := create(outPath, isoWorkDir, "ZTC SNO"); err != nil {
 		h.Log.WithError(err).Error("failed to create iso")
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/internal/imageserver/imageserver_test.go
+++ b/internal/imageserver/imageserver_test.go
@@ -102,6 +102,8 @@ var _ = Describe("ServeHttp", func() {
 		fs, err := d.GetFilesystem(0)
 		Expect(err).NotTo(HaveOccurred())
 
+		Expect(fs.Label()).To(HavePrefix("ZTC SNO"))
+
 		isoFile, err := fs.OpenFile("/file1", os.O_RDONLY)
 		Expect(err).NotTo(HaveOccurred())
 		content, err := io.ReadAll(isoFile)


### PR DESCRIPTION
The test uses `HavePrefix` as checking for exact equality leads to the following failure:

```
  [FAILED] Expected
      <string>: ZTC SNO\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00
  to equal
      <string>: ZTC SNO
```

cc @eranco74 

I just opened this to make this agree with the current state of https://github.com/eranco74/sno-relocation-poc/blob/master/bake/installation-configuration.sh#L26, it's up to you if you want to change it here or there.