### PR TITLE
MGMT-15282: Remove files and deprovision BMH when clusterconfig is removed

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -24,9 +24,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
+const (
+	Group   = "relocation.openshift.io"
+	Version = "v1alpha1"
+)
+
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "relocation.openshift.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/controllers/clusterconfig_controller_test.go
+++ b/controllers/clusterconfig_controller_test.go
@@ -95,8 +95,9 @@ var _ = Describe("Reconcile", func() {
 	It("creates a namespace file", func() {
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				ClusterRelocationSpec: cro.ClusterRelocationSpec{
@@ -128,8 +129,9 @@ var _ = Describe("Reconcile", func() {
 	It("creates the correct relocation content", func() {
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				ClusterRelocationSpec: cro.ClusterRelocationSpec{
@@ -172,8 +174,9 @@ var _ = Describe("Reconcile", func() {
 
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				ClusterRelocationSpec: cro.ClusterRelocationSpec{
@@ -239,8 +242,9 @@ var _ = Describe("Reconcile", func() {
 
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				NetworkConfigRef: &corev1.LocalObjectReference{
@@ -285,8 +289,9 @@ var _ = Describe("Reconcile", func() {
 
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				ExtraManifestsRef: &corev1.LocalObjectReference{
@@ -322,8 +327,9 @@ var _ = Describe("Reconcile", func() {
 
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				ExtraManifestsRef: &corev1.LocalObjectReference{
@@ -357,8 +363,9 @@ var _ = Describe("Reconcile", func() {
 
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
@@ -415,8 +422,9 @@ var _ = Describe("Reconcile", func() {
 
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
@@ -445,11 +453,22 @@ var _ = Describe("Reconcile", func() {
 		Expect(bmh.Annotations[detachedAnnotation]).To(Equal("clusterconfig-controller"))
 	})
 
+	It("doesn't error for a missing clusterconfig", func() {
+		key := types.NamespacedName{
+			Namespace: configNamespace,
+			Name:      configName,
+		}
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+	})
+
 	It("sets the image ready condition", func() {
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				ClusterRelocationSpec: cro.ClusterRelocationSpec{
@@ -492,8 +511,9 @@ var _ = Describe("Reconcile", func() {
 
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
@@ -523,8 +543,9 @@ var _ = Describe("Reconcile", func() {
 	It("sets the host configured condition to false when the host is missing", func() {
 		config := &relocationv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configName,
-				Namespace: configNamespace,
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
 			},
 			Spec: relocationv1alpha1.ClusterConfigSpec{
 				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
@@ -664,5 +685,196 @@ var _ = Describe("serviceURL", func() {
 			ServicePort:      "8080",
 		}
 		Expect(serviceURL(opts)).To(Equal("http://name.namespace:8080"))
+	})
+})
+
+var _ = Describe("handleFinalizer", func() {
+	var (
+		c               client.Client
+		dataDir         string
+		r               *ClusterConfigReconciler
+		ctx             = context.Background()
+		configName      = "test-config"
+		configNamespace = "test-namespace"
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithStatusSubresource(&relocationv1alpha1.ClusterConfig{}).
+			Build()
+		var err error
+		dataDir, err = os.MkdirTemp("", "clusterconfig_controller_test_data")
+		Expect(err).NotTo(HaveOccurred())
+
+		r = &ClusterConfigReconciler{
+			Client: c,
+			Scheme: scheme.Scheme,
+			Log:    logrus.New(),
+			Options: &ClusterConfigReconcilerOptions{
+				DataDir: dataDir,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(dataDir)).To(Succeed())
+	})
+
+	It("adds the finalizer if the config is not being deleted", func() {
+		config := &relocationv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configName,
+				Namespace: configNamespace,
+			},
+		}
+		Expect(c.Create(ctx, config)).To(Succeed())
+		res, stop, err := r.handleFinalizer(ctx, r.Log, config)
+		Expect(res).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(stop).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+
+		key := types.NamespacedName{
+			Name:      configName,
+			Namespace: configNamespace,
+		}
+		Expect(c.Get(ctx, key, config)).To(Succeed())
+		Expect(config.GetFinalizers()).To(ContainElement(clusterConfigFinalizerName))
+	})
+
+	It("noops if the finalizer is already present", func() {
+		config := &relocationv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
+			},
+		}
+		Expect(c.Create(ctx, config)).To(Succeed())
+		res, stop, err := r.handleFinalizer(ctx, r.Log, config)
+		Expect(res).To(Equal(ctrl.Result{}))
+		Expect(stop).To(BeFalse())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("deletes the local files when the config is deleted", func() {
+		config := &relocationv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
+			},
+		}
+		Expect(c.Create(ctx, config)).To(Succeed())
+
+		// mark config as deleted to call the finalizer handler
+		now := metav1.Now()
+		config.ObjectMeta.DeletionTimestamp = &now
+
+		filesDir := filepath.Join(dataDir, "namespaces", config.Namespace, config.Name, "files")
+		testFilePath := filepath.Join(filesDir, "testfile")
+		Expect(os.MkdirAll(filesDir, 0700)).To(Succeed())
+		Expect(os.WriteFile(testFilePath, []byte("stuff"), 0644)).To(Succeed())
+
+		res, stop, err := r.handleFinalizer(ctx, r.Log, config)
+		Expect(res).To(Equal(ctrl.Result{}))
+		Expect(stop).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = os.Stat(testFilePath)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+
+		key := types.NamespacedName{
+			Name:      configName,
+			Namespace: configNamespace,
+		}
+		Expect(c.Get(ctx, key, config)).To(Succeed())
+		Expect(config.GetFinalizers()).ToNot(ContainElement(clusterConfigFinalizerName))
+	})
+
+	It("removes the BMH image url when the config is deleted", func() {
+		bmh := &bmh_v1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-bmh",
+				Namespace: "test-bmh-namespace",
+			},
+			Spec: bmh_v1alpha1.BareMetalHostSpec{
+				Image: &bmh_v1alpha1.Image{
+					URL: "https://service.example.com/namespace/name.iso",
+				},
+			},
+		}
+		Expect(c.Create(ctx, bmh)).To(Succeed())
+
+		config := &relocationv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
+			},
+			Spec: relocationv1alpha1.ClusterConfigSpec{
+				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
+					Name:      bmh.Name,
+					Namespace: bmh.Namespace,
+				},
+			},
+		}
+		Expect(c.Create(ctx, config)).To(Succeed())
+
+		// mark config as deleted to call the finalizer handler
+		now := metav1.Now()
+		config.ObjectMeta.DeletionTimestamp = &now
+
+		res, stop, err := r.handleFinalizer(ctx, r.Log, config)
+		Expect(res).To(Equal(ctrl.Result{}))
+		Expect(stop).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+
+		bmhKey := types.NamespacedName{
+			Name:      bmh.Name,
+			Namespace: bmh.Namespace,
+		}
+		Expect(c.Get(ctx, bmhKey, bmh)).To(Succeed())
+		Expect(bmh.Spec.Image).To(BeNil())
+
+		configKey := types.NamespacedName{
+			Name:      configName,
+			Namespace: configNamespace,
+		}
+		Expect(c.Get(ctx, configKey, config)).To(Succeed())
+		Expect(config.GetFinalizers()).ToNot(ContainElement(clusterConfigFinalizerName))
+	})
+
+	It("removes the finalizer if the referenced BMH doesn't exist", func() {
+		config := &relocationv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       configName,
+				Namespace:  configNamespace,
+				Finalizers: []string{clusterConfigFinalizerName},
+			},
+			Spec: relocationv1alpha1.ClusterConfigSpec{
+				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
+					Name:      "test-bmh",
+					Namespace: "test-bmh-namespace",
+				},
+			},
+		}
+		Expect(c.Create(ctx, config)).To(Succeed())
+
+		// mark config as deleted to call the finalizer handler
+		now := metav1.Now()
+		config.ObjectMeta.DeletionTimestamp = &now
+
+		res, stop, err := r.handleFinalizer(ctx, r.Log, config)
+		Expect(res).To(Equal(ctrl.Result{}))
+		Expect(stop).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+
+		configKey := types.NamespacedName{
+			Name:      configName,
+			Namespace: configNamespace,
+		}
+		Expect(c.Get(ctx, configKey, config)).To(Succeed())
+		Expect(config.GetFinalizers()).ToNot(ContainElement(clusterConfigFinalizerName))
 	})
 })

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -24,39 +24,41 @@ func lockForDir(dir string) (*flock.Flock, error) {
 }
 
 // WithWriteLock runs the given function while holding a write lock on the directory `dir`
-// It returns a bool indicating whether the lock was acquired and any error that occurred acquiring the lock or running the function
-func WithWriteLock(dir string, f func() error) (bool, error) {
+// It returns a bool indicating whether the lock was acquired, any error that occurred acquiring
+// the lock, and the error value returned by the wrapped function
+func WithWriteLock(dir string, f func() error) (bool, error, error) {
 	lock, err := lockForDir(dir)
 	if err != nil {
-		return false, err
+		return false, err, nil
 	}
 	locked, err := lock.TryLock()
 	if err != nil {
-		return false, err
+		return false, err, nil
 	}
 	if !locked {
-		return false, nil
+		return false, nil, nil
 	}
 	defer lock.Unlock()
 
-	return true, f()
+	return true, nil, f()
 }
 
 // WithReadLock runs the given function while holding a read lock on the directory `dir`
-// It returns a bool indicating whether the lock was acquired and any error that occurred acquiring the lock or running the function
-func WithReadLock(dir string, f func() error) (bool, error) {
+// It returns a bool indicating whether the lock was acquired, any error that occurred acquiring
+// the lock, and the error value returned by the wrapped function
+func WithReadLock(dir string, f func() error) (bool, error, error) {
 	lock, err := lockForDir(dir)
 	if err != nil {
-		return false, err
+		return false, err, nil
 	}
 	locked, err := lock.TryRLock()
 	if err != nil {
-		return false, err
+		return false, err, nil
 	}
 	if !locked {
-		return false, nil
+		return false, nil, nil
 	}
 	defer lock.Unlock()
 
-	return true, f()
+	return true, nil, f()
 }

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -24,58 +24,64 @@ var _ = Describe("WithWriteLock", func() {
 	})
 
 	It("succeeds with no other locks", func() {
-		locked, err := WithWriteLock(dir, func() error { return nil })
+		locked, lerr, ferr := WithWriteLock(dir, func() error { return nil })
 		Expect(locked).To(BeTrue())
-		Expect(err).ToNot(HaveOccurred())
+		Expect(lerr).ToNot(HaveOccurred())
+		Expect(ferr).ToNot(HaveOccurred())
 	})
 
 	It("returns the inner function error", func() {
 		origError := fmt.Errorf("error")
-		locked, err := WithWriteLock(dir, func() error { return origError })
+		locked, lerr, ferr := WithWriteLock(dir, func() error { return origError })
 		Expect(locked).To(BeTrue())
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(Equal(origError))
+		Expect(lerr).ToNot(HaveOccurred())
+		Expect(ferr).To(HaveOccurred())
+		Expect(ferr).To(Equal(origError))
 	})
 
 	It("fails when a write lock is held already", func() {
 		c := make(chan int)
 
-		l1, err := WithWriteLock(dir, func() error {
+		l1, lerr, ferr := WithWriteLock(dir, func() error {
 			go func() {
 				defer func() { c <- 1 }()
-				l2, err := WithWriteLock(dir, func() error { return nil })
+				l2, lerr2, ferr2 := WithWriteLock(dir, func() error { return nil })
 				Expect(l2).To(BeFalse())
-				Expect(err).ToNot(HaveOccurred())
+				Expect(lerr2).ToNot(HaveOccurred())
+				Expect(ferr2).ToNot(HaveOccurred())
 			}()
 			<-c
 			return nil
 		})
 		Expect(l1).To(BeTrue())
-		Expect(err).NotTo(HaveOccurred())
+		Expect(lerr).NotTo(HaveOccurred())
+		Expect(ferr).NotTo(HaveOccurred())
 	})
 
 	It("fails when a read lock is held already", func() {
 		c := make(chan int)
 
-		l1, err := WithReadLock(dir, func() error {
+		l1, lerr, ferr := WithReadLock(dir, func() error {
 			go func() {
 				defer func() { c <- 1 }()
-				l2, err := WithWriteLock(dir, func() error { return nil })
+				l2, lerr2, ferr2 := WithWriteLock(dir, func() error { return nil })
 				Expect(l2).To(BeFalse())
-				Expect(err).ToNot(HaveOccurred())
+				Expect(lerr2).ToNot(HaveOccurred())
+				Expect(ferr2).ToNot(HaveOccurred())
 			}()
 			<-c
 			return nil
 		})
 		Expect(l1).To(BeTrue())
-		Expect(err).NotTo(HaveOccurred())
+		Expect(lerr).NotTo(HaveOccurred())
+		Expect(ferr).NotTo(HaveOccurred())
 	})
 
 	It("fails if the directory doesn't exist", func() {
 		Expect(os.RemoveAll(dir)).To(Succeed())
-		locked, err := WithWriteLock(dir, func() error { return nil })
+		locked, lerr, _ := WithWriteLock(dir, func() error { return nil })
 		Expect(locked).To(BeFalse())
-		Expect(err).To(HaveOccurred())
+		Expect(lerr).To(HaveOccurred())
 	})
 })
 
@@ -94,58 +100,64 @@ var _ = Describe("WithReadLock", func() {
 	})
 
 	It("succeeds with no other locks", func() {
-		locked, err := WithReadLock(dir, func() error { return nil })
+		locked, lerr, ferr := WithReadLock(dir, func() error { return nil })
 		Expect(locked).To(BeTrue())
-		Expect(err).ToNot(HaveOccurred())
+		Expect(lerr).ToNot(HaveOccurred())
+		Expect(ferr).ToNot(HaveOccurred())
 	})
 
 	It("returns the inner function error", func() {
 		origError := fmt.Errorf("error")
-		locked, err := WithReadLock(dir, func() error { return origError })
+		locked, lerr, ferr := WithReadLock(dir, func() error { return origError })
 		Expect(locked).To(BeTrue())
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(Equal(origError))
+		Expect(lerr).ToNot(HaveOccurred())
+		Expect(ferr).To(HaveOccurred())
+		Expect(ferr).To(Equal(origError))
 	})
 
 	It("succeeds when a read lock is held already", func() {
 		c := make(chan int)
 
-		l1, err := WithReadLock(dir, func() error {
+		l1, lerr, ferr := WithReadLock(dir, func() error {
 			go func() {
 				defer func() { c <- 1 }()
-				l2, err := WithReadLock(dir, func() error { return nil })
+				l2, lerr2, ferr2 := WithReadLock(dir, func() error { return nil })
 				Expect(l2).To(BeTrue())
-				Expect(err).ToNot(HaveOccurred())
+				Expect(lerr2).ToNot(HaveOccurred())
+				Expect(ferr2).ToNot(HaveOccurred())
 			}()
 			<-c
 			return nil
 		})
 		Expect(l1).To(BeTrue())
-		Expect(err).NotTo(HaveOccurred())
+		Expect(lerr).NotTo(HaveOccurred())
+		Expect(ferr).NotTo(HaveOccurred())
 	})
 
 	It("fails when a write lock is held already", func() {
 		c := make(chan int)
 
-		l1, err := WithWriteLock(dir, func() error {
+		l1, lerr, ferr := WithWriteLock(dir, func() error {
 			go func() {
 				defer func() { c <- 1 }()
-				l2, err := WithReadLock(dir, func() error { return nil })
+				l2, lerr2, ferr2 := WithReadLock(dir, func() error { return nil })
 				Expect(l2).To(BeFalse())
-				Expect(err).ToNot(HaveOccurred())
+				Expect(lerr2).ToNot(HaveOccurred())
+				Expect(ferr2).ToNot(HaveOccurred())
 			}()
 			<-c
 			return nil
 		})
 		Expect(l1).To(BeTrue())
-		Expect(err).NotTo(HaveOccurred())
+		Expect(lerr).NotTo(HaveOccurred())
+		Expect(ferr).NotTo(HaveOccurred())
 	})
 
 	It("fails if the directory doesn't exist", func() {
 		Expect(os.RemoveAll(dir)).To(Succeed())
-		locked, err := WithReadLock(dir, func() error { return nil })
+		locked, lerr, _ := WithReadLock(dir, func() error { return nil })
 		Expect(locked).To(BeFalse())
-		Expect(err).To(HaveOccurred())
+		Expect(lerr).To(HaveOccurred())
 	})
 })
 


### PR DESCRIPTION
Adds a finalizer to clusterconfig resources that allows the controller
to clean up the local files for that config and remove the image
reference from a linked BMH.

Resolves https://issues.redhat.com/browse/MGMT-15282