### PR TITLE
Add secrets reader permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,14 @@ metadata:
   name: cluster-config-manager
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - metal3.io
   resources:
   - baremetalhosts

--- a/controllers/clusterconfig_controller.go
+++ b/controllers/clusterconfig_controller.go
@@ -59,6 +59,7 @@ type ClusterConfigReconciler struct {
 	BaseURL string
 }
 
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=relocation.openshift.io,resources=clusterconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=relocation.openshift.io,resources=clusterconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=relocation.openshift.io,resources=clusterconfigs/finalizers,verbs=update


### PR DESCRIPTION
This is required to read the secrets referrenced in the clusterconfig spec. Without this referencing a secret in the clusterconfig would fail the reconcile with an rbac error.

cc @achuzhoy 