### PR TITLE
Make kustomize image substitution work properly

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: quay.io/carbonin/cluster-relocation-service:latest
+        image: controller:latest
         name: manager
         env:
         - name: SERVICE_NAMESPACE
@@ -71,7 +71,7 @@ spec:
           mountPath: /data
       - command:
         - /server
-        image: quay.io/carbonin/cluster-relocation-service:latest
+        image: controller:latest
         name: server
         ports:
         - name: config-server


### PR DESCRIPTION
This is required for `make deploy` to properly substitute the image using the `IMG` env var.

Without this `quay.io/carbonin/cluster-relocation-service:latest` is used unconditionally.

cc @achuzhoy 