### PR TITLE
Use correct cluster relocation CR name

### DIFF
--- a/controllers/clusterconfig_controller.go
+++ b/controllers/clusterconfig_controller.go
@@ -60,7 +60,10 @@ type ClusterConfigReconciler struct {
 	BaseURL string
 }
 
-const detachedAnnotation = "baremetalhost.metal3.io/detached"
+const (
+	detachedAnnotation    = "baremetalhost.metal3.io/detached"
+	clusterRelocationName = "cluster"
+)
 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=relocation.openshift.io,resources=clusterconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -277,7 +280,7 @@ func (r *ClusterConfigReconciler) writeInputData(ctx context.Context, config *re
 func (r *ClusterConfigReconciler) writeClusterRelocation(config *relocationv1alpha1.ClusterConfig, file string) error {
 	cr := &cro.ClusterRelocation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.Name,
+			Name:      clusterRelocationName,
 			Namespace: config.Namespace,
 		},
 		Spec: config.Spec.ClusterRelocationSpec,

--- a/controllers/clusterconfig_controller_test.go
+++ b/controllers/clusterconfig_controller_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Reconcile", func() {
 		relocation := &cro.ClusterRelocation{}
 		Expect(json.Unmarshal(content, relocation)).To(Succeed())
 		Expect(relocation.Spec).To(Equal(config.Spec.ClusterRelocationSpec))
-		Expect(relocation.Name).To(Equal(configName))
+		Expect(relocation.Name).To(Equal(clusterRelocationName))
 		Expect(relocation.Namespace).To(Equal(configNamespace))
 		Expect(relocation.Kind).To(Equal("ClusterRelocation"))
 		Expect(relocation.APIVersion).To(Equal("rhsyseng.github.io/v1beta1"))


### PR DESCRIPTION
The cluster relocation operator requires the cluster relocation CR to be named "cluster"

ref: https://github.com/RHsyseng/cluster-relocation-operator/blob/3fa806e8136f8fe02e8aab3abec6878a28efedbc/controllers/clusterrelocation_controller.go#L280

Resolves https://issues.redhat.com/browse/MGMT-15523

cc @achuzhoy 